### PR TITLE
replace RARRAY_PTR with RARRAY_CONST_PTR

### DIFF
--- a/ext/seven_zip_ruby/seven_zip_archive.cpp
+++ b/ext/seven_zip_ruby/seven_zip_archive.cpp
@@ -505,7 +505,7 @@ VALUE ArchiveReader::extractFiles(VALUE index_list, VALUE callback_proc)
     fillEntryInfo();
 
     std::vector<UInt32> list(RARRAY_LEN(index_list));
-    std::transform(RARRAY_PTR(index_list), RARRAY_PTR(index_list) + RARRAY_LEN(index_list),
+    std::transform(RARRAY_CONST_PTR(index_list), RARRAY_CONST_PTR(index_list) + RARRAY_LEN(index_list),
                    list.begin(), [](VALUE num){ return NUM2ULONG(num); });
 
     HRESULT ret;


### PR DESCRIPTION
With ruby 2.3.0 this gem does not compile anymore as the naming has changed as above. Unfortunately I am only able to compile this using Linux (`gcc (Debian 4.9.2-10) 4.9.2`). On OS X I have not been able to compile this. If someone could give me a hand, that would be greatly appreciated, as I don't have much experience with native extensions.

If there is anything I can help with I will be glad to do so.

PS: Thank you for this gem, it saved me a ton of time in the first place.