### PR TITLE
Fixed issue with ruby v 2.3.x added backward compatibility

### DIFF
--- a/ext/seven_zip_ruby/seven_zip_archive.cpp
+++ b/ext/seven_zip_ruby/seven_zip_archive.cpp
@@ -13,6 +13,9 @@
 
 #define INTERN(const_str) rb_intern2(const_str, sizeof(const_str) - 1)
 
+#ifndef RARRAY_CONST_PTR
+#define RARRAY_CONST_PTR(index_list) RARRAY_PTR (index_list)
+#endif
 
 ////////////////////////////////////////////////////////////////
 namespace SevenZip
@@ -505,7 +508,7 @@ VALUE ArchiveReader::extractFiles(VALUE index_list, VALUE callback_proc)
     fillEntryInfo();
 
     std::vector<UInt32> list(RARRAY_LEN(index_list));
-    std::transform(RARRAY_PTR(index_list), RARRAY_PTR(index_list) + RARRAY_LEN(index_list),
+    std::transform(RARRAY_CONST_PTR(index_list), RARRAY_CONST_PTR(index_list) + RARRAY_LEN(index_list),
                    list.begin(), [](VALUE num){ return NUM2ULONG(num); });
 
     HRESULT ret;


### PR DESCRIPTION
@masamitsu-murase sorry for one more PR for same issue.

I've added backward compatibility in sources and tested on versions defined for travisci.
Now it works good.
Looks like rvm rid of `RARRAY_PTR` and now it colls `RARRAY_CONST_PTR`.
That's why we have failed build on older versions.
Please check it. Thank you.