### PR TITLE
Fix: Dll Loading

### DIFF
--- a/ext/seven_zip_ruby/extconf.rb
+++ b/ext/seven_zip_ruby/extconf.rb
@@ -140,11 +140,11 @@ def main
 
   if (RUBY_PLATFORM.include?("mswin"))
     # mswin32
-    $LIBS = "oleaut32.lib"
+    $LIBS = "oleaut32.lib shlwapi.lib"
     $CPPFLAGS = "/I.. /EHsc /DNDEBUG /DUSE_WIN32_FILE_API #{base_flag} #{$CPPFLAGS} "
   elsif (RUBY_PLATFORM.include?("mingw"))
     # MinGW
-    $LIBS = "-loleaut32 -static-libgcc -static-libstdc++"
+    $LIBS = "-loleaut32 -lshlwapi -static-libgcc -static-libstdc++"
 
     cpp0x_flag = [ "", "-std=gnu++11", "-std=c++11", "-std=gnu++0x", "-std=c++0x" ].find do |opt|
       try_compile(sample_cpp_source, "#{opt} -x c++ ")


### PR DESCRIPTION
Windows 版の Ruby 2.6 で 7z.dll が読み込めなかった問題の修正です。 Dll Preloading Attacks への対応も含みます。

gem install seven_zip_ruby_am でインストールしたソースを変更し、簡単に動作を確認しました。使用した Ruby は RubyInstaller 版の ruby 2.6.5p114 (2019-10-01 revision 67812) [x64-mingw32] です。


DLL プリロード攻撃を防止するためのライブラリの安全な読み込み <https://support.microsoft.com/ja-jp/help/2389418/secure-loading-of-libraries-to-prevent-dll-preloading-attacks>