### PR TITLE
Locate SO_TARGET_DIR with gem rather than system

### DIFF
--- a/ext/seven_zip_ruby/extconf.rb
+++ b/ext/seven_zip_ruby/extconf.rb
@@ -3,8 +3,8 @@
 require("mkmf")
 require("rbconfig")
 
-
-SO_TARGET_DIR = File.expand_path(File.join(RbConfig::CONFIG["sitearchdir"], "seven_zip_ruby"))
+# Place the .so at $GEM_HOME/gems/seven_zip_ruby-<version>/lib/seven_zip_ruby/7z.so
+SO_TARGET_DIR = File.join(File.expand_path("../../../lib", __FILE__), "seven_zip_ruby")
 
 def create_p7zip_makefile(type)
   config = RbConfig::CONFIG


### PR DESCRIPTION
Previously, `SO_TARGET_DIR` was hardcoded to install the built 7z.so into `RbConfig::CONFIG["sitearchdir"]`, which is typically located wherever ruby is installed.

This is seems like an unusual thing for a gem to do, and breaks if ruby is installed in a read only location. It also breaks caching assumptions for some PaaS rails hosts, like Heroku.

This PR tweaks `SO_TARGET_DIR` so that 7z.so is instead installed in the gem directory with the rest of the `seven_zib_ruby`, i.e. `$GEM_HOME/gems/seven_zip_ruby-1.3.0/lib` which I think falls back to `~/.gem/ruby/2.7.0/gems/seven_zip_ruby-1.3.0/lib`

This change allows seven_zip_ruby to build on my system, and I can also `require "seven_zip_ruby"` successfully. I also believe that this will not impact other users.

Fixes #41 and fixes #42 